### PR TITLE
FIX - nfc_adapter not triggering screen

### DIFF
--- a/android/app/src/main/kotlin/com/example/bookpal/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/bookpal/MainActivity.kt
@@ -1,6 +1,21 @@
 package com.example.bookpal
 
+import android.app.PendingIntent
+import android.content.Intent
+import android.nfc.NfcAdapter
 import io.flutter.embedding.android.FlutterActivity
 
+// Extracted from https://github.com/okadan/nfc-manager/blob/master/android/app/src/main/kotlin/com/naokiokada/nfcmanager/MainActivity.kt
 class MainActivity: FlutterActivity() {
+  override fun onResume() {
+    super.onResume()
+    val intent = Intent(context, javaClass).addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
+    val pendingIntent = PendingIntent.getActivity(context, 0, intent, 0)
+    NfcAdapter.getDefaultAdapter(context)?.enableForegroundDispatch(this, pendingIntent, null, null)
+  }
+
+  override fun onPause() {
+    super.onPause()
+    NfcAdapter.getDefaultAdapter(context)?.disableForegroundDispatch(this)
+  }
 }

--- a/lib/device/devices/nfc_adapter/nfc_adapter.dart
+++ b/lib/device/devices/nfc_adapter/nfc_adapter.dart
@@ -22,10 +22,19 @@ class NfcAdapter {
           if (ndef == null) {
             return;
           }
-          logger.d("Reading tag $tag");
-          logger.d("Stopping session");
+          if (ndef.cachedMessage != null) {
+            String tempRecord = "";
+            for (var record in ndef.cachedMessage!.records) {
+              tempRecord =
+              "$tempRecord ${String.fromCharCodes(record.payload.sublist(record.payload[0] + 1))}";
+            }
+            logger.d(tempRecord);
+            // TODO: controller.add(tempRecord)
+          } else {
+            logger.d("Missing data");
+            // TODO: Handle this
+          }
           instance.stopSession();
-          controller.add(await ndef.read());
           controller.close();
         },
         alertMessage: "Approach a tag to the back of your phone.",


### PR DESCRIPTION
I applied the suggested modifications to the MainActivity.java as per [Stack Overflow](https://stackoverflow.com/a/77357058), I encountered an ongoing issue and I came across a [Medium post](https://medium.com/@antonioneus/reading-and-writing-nfc-using-nfcmanager-in-flutter-dc5420991967) where they avoid using the .read() method to directly extract the actual data from the encoded data.

Considering this alternative approach, it seems that avoiding the .read() method might provide a solution. If we decide to incorporate this change, we will also need to adjust subsequent methods to handle string values. Please review and advise on the best course of action

The only remaining issue is that is always scanning.